### PR TITLE
Added smooth scrolling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,62 +1,73 @@
 ---
 ---
+
 <!DOCTYPE html>
 <html dir="ltr" lang="de">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ page.title }}</title>
-	<meta name="keywords" content="{{ site.keywords }}">
-	<meta name="description" content="{{ site.description }}">
-  <link rel="stylesheet" href="combo.css">
-  <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
-  {% if site.favicon %}<link rel="shortcut icon" href="{{ site.favicon }}" type="image/x-icon">{% endif %}
-	{% if site.touch_icon %}<link rel="apple-touch-icon" href="{{ site.touch_icon }}">{% endif %}
-</head>
-<body>
-  <div id="main">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ page.title }}</title>
+    <meta name="keywords" content="{{ site.keywords }}" />
+    <meta name="description" content="{{ site.description }}" />
+    <link rel="stylesheet" href="combo.css" />
+    <link
+      href="http://fonts.googleapis.com/css?family=Raleway:400,300,700"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      rel="stylesheet"
+      href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css"
+    />
+    {% if site.favicon %}
+    <link rel="shortcut icon" href="{{ site.favicon }}" type="image/x-icon" />
+    {% endif %} {% if site.touch_icon %}
+    <link rel="apple-touch-icon" href="{{ site.touch_icon }}" />
+    {% endif %}
+  </head>
+  <body>
+    <div id="main">
+      <!-- Menüleiste -->
+      <nav>
+        <ul>
+          {% for node in site.posts reversed %} {% capture id %}{{ node.id |
+          remove:'/' | downcase }}{% endcapture %} {% if
+          node.style=="sectionbackground" %} {% else %} {% if node.type=="title"
+          %}
+          <li class="p-{{id}}">
+            <a href="/#{{id}}">{{node.title}}</a>
+          </li>
+          {% endif %} {% endif %} {% endfor %}
+          <li class="p-news"><a href="/news">News</a></li>
+        </ul>
+      </nav>
 
-    <!-- Menüleiste -->
-    <nav>
-      <ul>
-        {% for node in site.posts reversed %}
-        {% capture id %}{{ node.id | remove:'/' | downcase }}{% endcapture %}
-          {% if node.style=="sectionbackground" %}
-          {% else %}
-            {% if node.type=="title" %}
-              <li class="p-{{id}}"><a href="{{ site.url }}#{{id}}">{{node.title}}</a></li>
-            {% endif %}
-          {% endif %}
-        {% endfor %}
-        <li class="p-news"><a href="{{ site.url }}/news">News</a></li>
-      </ul>
-    </nav>
+      {{ content }}
 
-    {{ content }}
-
-
-    <!-- Fußzeile / Abspann / Danksagung -->
-    <div id="footer" class="section text-white">
-      <div class="container">
-        {% capture foottext1 %} {% include footer1.md %} {% endcapture %}
-        {% capture foottext2 %} {% include footer2.md %} {% endcapture %}
-        {% capture foottext3 %} {% include footer3.md %} {% endcapture %}
-        <table>
-          <tr>
-            <td> {{ foottext1 | markdownify }} </td>
-            <td> {{ foottext2 | markdownify }} </td>
-            <td> {{ foottext3 | markdownify }} </td>
-          </tr>
-        </table>
+      <!-- Fußzeile / Abspann / Danksagung -->
+      <div id="footer" class="section text-white">
+        <div class="container">
+          {% capture foottext1 %} {% include footer1.md %} {% endcapture %} {%
+          capture foottext2 %} {% include footer2.md %} {% endcapture %} {%
+          capture foottext3 %} {% include footer3.md %} {% endcapture %}
+          <table>
+            <tr>
+              <td>{{ foottext1 | markdownify }}</td>
+              <td>{{ foottext2 | markdownify }}</td>
+              <td>{{ foottext3 | markdownify }}</td>
+            </tr>
+          </table>
+        </div>
       </div>
     </div>
-  </div>
 
-{% include analytics.html %}
-</body>
-<!--
+    {% include analytics.html %}
+  </body>
+  <!--
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="site.js"></script>
 -->
+
+  <!-- smooth scrolling für seiten-interne <a> tags -->
+  <script src="/smooth-scrolling.js"></script>
 </html>

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -1,0 +1,22 @@
+// Skript für weiche Scroll-Animation bei seiteninternen Links
+// Browser support: https://caniuse.com/scrollintoview
+
+// Quelle: stackoverflow.com/questions/7717527/smooth-scrolling-when-clicking-an-anchor-link#answer-7717572
+
+// Anpassung zum Original:
+// Es sollen ausschließlich die Anchor gematcht werden, deren Pfad dem aktuellen window.location.pathname entspricht
+// Andernfalls würde versucht werden, andere Seiten mit ScrollIntoView aufzurufen. 
+const siteSpecificAnchorSelector = `a[href^="${window.location.pathname}#"]`
+
+document.querySelectorAll(siteSpecificAnchorSelector).forEach(anchor => {
+  console.log(anchor)
+  anchor.addEventListener('click', function (e) {
+    e.preventDefault();
+
+    // weil der Pfadname mit in der href mit auftaucht, muss ID extra ausgelesen werden 
+    const anchorTargetId = this.getAttribute('href').split('#')[1]
+    document.getElementById(anchorTargetId).scrollIntoView({
+      behavior: 'smooth'
+    });
+  });
+});


### PR DESCRIPTION
`default.html` bindet jetzt das Skript `smooth-scrolling.js` ein. 
`smooth-scrolling.js` ersetzt das default-Verhalten der anchor-tags mit Zielen auf derselben Seite durch die [`scrollIntoView` Funktion](https://w3c.github.io/csswg-drafts/cssom-view/#dom-element-scrollintoview).
Außerdem ist der Leserlichkeit-halber die ausgeschriebene Origin aus dem href der Links entfernt, da das Präsifx `/` denselben Effekt hat.